### PR TITLE
Add in API Guidelines to playbook and combine docs repos

### DIFF
--- a/12-factor.md
+++ b/12-factor.md
@@ -9,7 +9,7 @@ The Twelve Factor App Methodology is suggested by developers for smoothly workin
 For example :https://github.com/LBHackney-IT/LBHTenancyAPI
 
 You should always have one repository for an individual application to ease CI/CD pipelines. Also you can have multiple repositories for a microservice.
-The codebase is the same across all deployments, although different versions may be active in each deployment. For example, a developer has some commits not yet deployed to staging; staging will have some commits which are not yet deployed to production environment. But they all share the same codebase, thus making them identifiable as different deployments of the same application. Working in the open allows us to have feedback from a wider audience thus giving an opportunity to improve the code quality.
+The codebase is the same across all deployments, although different versions may be active in each deployment. For example, a developer has some commits not yet deployed to staging; staging will have some commits which are not yet deployed to the production environment. But they all share the same codebase, thus making them identifiable as different deployments of the same application. Deployments should only be normally made from the CI, not from developers machine.  Working in the open allows us to have feedback from a wider audience thus giving an opportunity to improve the code quality.
 
 ## 2. Explicitly declare and isolate dependencies
 

--- a/12-factor.md
+++ b/12-factor.md
@@ -1,0 +1,80 @@
+# 12 Factor App : Hackney Development Standards
+
+The Twelve Factor App Methodology is suggested by developers for smoothly working and delivering Software as a Service (SaaS) Applications or Web Apps with a focus on Microservices. 
+
+## 1. One codebase tracked in revision control, many deploys
+
+- *As a developer I should put my application code in GitHub so that I can showcase my work, get review and feedback from a wider group than my colleagues.*
+
+For example :https://github.com/LBHackney-IT/LBHTenancyAPI
+
+You should always have one repository for an individual application to ease CI/CD pipelines. Also you can have multiple repositories for a microservice.
+The codebase is the same across all deployments, although different versions may be active in each deployment. For example, a developer has some commits not yet deployed to staging; staging will have some commits which are not yet deployed to production environment. But they all share the same codebase, thus making them identifiable as different deployments of the same application. Working in the open allows us to have feedback from a wider audience thus giving an opportunity to improve the code quality.
+
+## 2. Explicitly declare and isolate dependencies
+
+- *As a developer I should not copy any dependencies to the project codebase, rather use dependency management tools to get the required project dependencies, declared in manifest, from the server.*
+
+Your application might rely on external libraries/dependencies and packages to run.As fair point you should never assume that these packages,dependencies exist on the target system. Instead, your application must declare all dependencies and their correct version explicitly.
+
+It is preferable to use a package/dependency manager such as nuget package for C# or npm for Nodejs to manage and resolve dependencies.
+
+## 3. Store config in the environment
+
+- *As a developer I should make sure all configuration data is stored in a separate place from the code, and read in by the code at runtime.*
+
+Configuration options should never be hardcoded, for two reasons:
+- You do not want sensitive information like database credentials, server details or API keys to be committed into the repository to prevent security leaks.
+- Your configuration varies per environment. For example, you might want to enable debugging on your local environment while this would be a problem on production.
+
+Also avoid storing sensitive data in source control. One way to avoid this is to use environment variables to configure sensitive settings such as access keys.
+
+## 4. Treat backing services as attached resources
+
+- *As a developer I should treat backing services as attached resources.*
+
+A backing service is one which requires a network connection to run, like MySQL. If the location or connection details of such service changes, then you should not have to make code changes. Instead, these details should be available in the configuration.
+
+## 5. Strictly separate build and run stages
+
+- *As a developer I want make sure to strictly separate the Build and Run stages making sure everything has the right libraries so that  automation and maintaining the system will be as easy as possible.*
+
+As we all know that it’s now impossible to make changes during the runtime. Instead, it is suggested that to make changes to the code in the build stage where you have total control on it. This reduces risk and ensures your team that everything is running well.
+
+## 6. Execute the app as  one or more stateless processes
+
+- *As a developer I want to make sure to execute the app as one or more stateless processes so that even if a single process fails, this can be killed and another process replace it without incident, this also is the foundation of scalable and reliable applications.*
+
+In other words, the state of your system is completely defined by your databases and shared storage, and not by each individual running application instance.
+
+## 7. Export services via port binding
+
+- *As a developer I should break my app into much smaller pieces and then look for services out there that I either have to write or can consume so that the application becomes self-contained.*
+
+## 8. Scale out via the process model
+
+_ *As a developer I need to make sure that the processes are less time consuming. Applications should be started or stopped in minimal time so that sustainability and scalability of your application is improved.*
+
+In other words each application should be able restart, scale or clone itself whenever needed.
+
+## 9. Maximize robustness with fast startup and graceful shutdown
+
+- *As a developer I need to make sure that my application is robust. This will ensure that even if it does encounter an unexpected critical failure, it should always be able to start back up cleanly.*
+
+In other words after a unexpected critical failure (crash) or any new deployment, your app should have everything it needs waiting in databases or caches. We should always make sure that rebooting an application is as swift as possible.
+
+## 10. Keep development, staging and production as similar as possible
+
+- *As a developer, infrastructure and support analyst I will make sure that there is continuous deployments by keeping less gaps between production and development environments so that it allows to have rapid development cycle.*
+
+By having development environment to be clone of production environment reduces number of bugs and downtime and also allows you to work in the same environment,services and dependencies.  This also implies the staging environment is handled with the same care as production and allows you to test and UAT scenarios as close to their goal environment as possible.
+
+## 11. Treat logs as event streams
+
+- *As a developer I will make sure that applications have a logging mechanism in place so that developers can debug problems across microservices and resolve them.*
+
+Having a logging mechanism in place allows developers to identify problems, debug through the code and resolve it. 
+
+## 12. Run admin/management asks as one-off processes
+
+- *As a developer run admin/management tasks as one-off processes — tasks like database migration or executing one-off scripts in the environment.*

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A guide on Hackney's development practices, and how to follow them.
 
 - [Application standards](#application-standards)
   - [Open source on GitHub](#open-source-on-GitHub)
+  - [Follow the API Guidelines](#follow-the-api-guidelines)
   - [Test-driven approach](#test-driven-approach)
   - [12 Factor](#12-factor)
 - [Monitoring](#monitoring)
@@ -27,6 +28,10 @@ A guide on Hackney's development practices, and how to follow them.
 Our mission is to open source 100% of our code, and start in the open whenever starting new projects. All of our code repositories are on GitHub, over half are currently open source.
 
 By employing a [12 Factor](#12-factor) methodology, we keep any secrets such as API tokens outside of our repositories, and instead injected as environment variables in trusted runtime environments. This allows us to write code which interacts with private systems without exposing information.
+
+### Follow the API Guidelines
+
+We have documented our [guidelines][guidelines] for building ReSTful APIs for use in Hackney. These cover the specifics of how an API should be built, including how we implement ReST, HTTP standards, JSON data format, etc. This ensures that all Hackney APIs are built to the same standard and hva consistency across all endpoints.
 
 ### 12 Factor
 
@@ -211,3 +216,4 @@ In a Ruby application you can use the `swagger-blocks` gem, which provides a DSL
 [learn-tech-practice-tdd]: https://learn.madetech.com/core-skills/tdd/
 [ca]: https://github.com/madetech/clean-architecture
 [pingdom]: https://www.pingdom.com
+[guidelines]: api-guidelines/README.md

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ A guide on Hackney's development practices, and how to follow them.
 - [Application standards](#application-standards)
   - [Open source on GitHub](#open-source-on-GitHub)
   - [Test-driven approach](#test-driven-approach)
+  - [12 Factor](#12-factor)
 - [Monitoring](#monitoring)
   - [Centralised logging](#centralised-logging)
   - [Centralised application performance monitoring](#centralised-application-performance-monitoring)
   - [Centralised exception logging](#centralised-exception-logging)
-  - [12 Factor](#12-factor)
 - [Containers](#containers)
 - [Hosting](#hosting)
   - [ECS](#ecs)
@@ -27,6 +27,12 @@ A guide on Hackney's development practices, and how to follow them.
 Our mission is to open source 100% of our code, and start in the open whenever starting new projects. All of our code repositories are on GitHub, over half are currently open source.
 
 By employing a [12 Factor](#12-factor) methodology, we keep any secrets such as API tokens outside of our repositories, and instead injected as environment variables in trusted runtime environments. This allows us to write code which interacts with private systems without exposing information.
+
+### 12 Factor
+
+We follow 12 Factor principles when building new applications. You can find out more about why [in our Hackney Development Standards documentation][12-factor-documentation].
+
+Following these principles allows our applications to be platform agnostic, meaning we're not tied down to running them on any specific vendor's platform, and don't have to make changes to application code in order to migrate them somewhere else.
 
 ### Test-driven approach
 
@@ -77,12 +83,6 @@ It is very useful for developers/maintainers to investigate and fix application 
 In a .NET application, you install a Sentry package using NuGet and use it to send messages to Sentry when handling uncaught exceptions. You can find an example of this in the [Tenancy API][dotnet-sentry-example].
 
 In a Ruby application, you install the Sentry gem and configure it to add additional context. You can find an example of setting this up in the [Income API][ruby-sentry-example].
-
-### 12 Factor
-
-We follow 12 Factor principles when building new applications. You can find out more about why [in our Hackney Development Standards documentation][12-factor-documentation].
-
-Following these principles allows our applications to be platform agnostic, meaning we're not tied down to running them on any specific vendor's platform, and don't have to make changes to application code in order to migrate them somewhere else.
 
 ## Containers
 
@@ -201,7 +201,7 @@ In a Ruby application you can use the `swagger-blocks` gem, which provides a DSL
 [ruby-newrelic-example]: https://github.com/LBHackney-IT/lbh-income-api/commit/98f7c574449c732962d73c4b907daaa1ed2e9b42
 [dotnet-sentry-example]: https://github.com/LBHackney-IT/LBHTenancyAPI/blob/bd56e77d10f61598be778e7b65630e7632c2afc7/LBHTenancyAPI/Infrastructure/V1/Logging/SentryLogger.cs
 [ruby-sentry-example]: https://github.com/LBHackney-IT/lbh-income-api/commit/058a87b7de1a71c922ac5d9eaac9117b10df88d2
-[12-factor-documentation]: https://github.com/LBHackney-IT/Hackney-Development-Standards
+[12-factor-documentation]: ./12-factor.md
 [universal-housing-simulator]: http://example.com
 [made-tech]: https://www.madetech.com/
 [dotnet-swagger-example]: https://github.com/LBHackney-IT/LBHTenancyAPI/blob/master/LBHTenancyAPI/Startup.cs#L65-L112

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ A guide on Hackney's development practices, and how to follow them.
 - [Monitoring](#monitoring)
   - [Centralised logging](#centralised-logging)
   - [Centralised application performance monitoring](#centralised-application-performance-monitoring)
+  - [Centralised uptime monitoring](#centralised-uptime-monitoring)
   - [Centralised exception logging](#centralised-exception-logging)
+  - [Health Checks](#health-checks)
 - [Containers](#containers)
 - [Hosting](#hosting)
   - [ECS](#ecs)
@@ -88,6 +90,12 @@ It is very useful for developers/maintainers to investigate and fix application 
 In a .NET application, you install a Sentry package using NuGet and use it to send messages to Sentry when handling uncaught exceptions. You can find an example of this in the [Tenancy API][dotnet-sentry-example].
 
 In a Ruby application, you install the Sentry gem and configure it to add additional context. You can find an example of setting this up in the [Income API][ruby-sentry-example].
+
+### Health Checks
+
+As a developer I should make sure that I build 'Health Check API endpoints' to monitor is service up and report back if it goes down.
+
+Also health checks can also be used by monitoring tools to track and alert on the availability and performance of the service, where they serve as early problem indicators. For eg Sentry for exception logging,New relic for application monitoring.
 
 ## Containers
 

--- a/api-guidelines/README.md
+++ b/api-guidelines/README.md
@@ -1,0 +1,24 @@
+# API Standards
+
+## Introduction
+
+These are a set of API guidelines based on the excellent set created by [Zalando](https://github.com/zalando/restful-api-guidelines).
+
+## Contents
+
+* [Design Principles](./standards/design-principles.md)
+* [General Guidelines](./standards/general-guidelines.md)
+* [Security](./standards/security.md)
+* [Compatibility](./standards/compatibility.md)
+* [Deprecation](./standards/deprecation.md)
+* [Naming](./standards/naming.md)
+* [HTTP](./standards/http.md)
+* [Resources](./standards/resources.md)
+* [Pagination](./standards/pagination.md)
+* [Data Formats](./standards/data-formats.md)
+* [Operation](./standards/operation.md)
+* [References](./standards/references.md)
+
+## Conventions
+
+The requirement level keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" used in this document (case insensitive) are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119.txt). The titles are marked with the corresponding labels.

--- a/api-guidelines/README.md
+++ b/api-guidelines/README.md
@@ -1,23 +1,25 @@
-# API Standards
+# Hackney API Implementation Guidelines
 
 ## Introduction
 
-These are a set of API guidelines based on the excellent set created by [Zalando](https://github.com/zalando/restful-api-guidelines).
+There are an increasing number of APIs being developed at Hackney and these guidelines are designed to provide a clear set of implementation guides to bring consistency between the different endpoints.
+
+They are based on the excellent set created by [Zalando](https://github.com/zalando/restful-api-guidelines).
 
 ## Contents
 
-* [Design Principles](./standards/design-principles.md)
-* [General Guidelines](./standards/general-guidelines.md)
-* [Security](./standards/security.md)
-* [Compatibility](./standards/compatibility.md)
-* [Deprecation](./standards/deprecation.md)
-* [Naming](./standards/naming.md)
-* [HTTP](./standards/http.md)
-* [Resources](./standards/resources.md)
-* [Pagination](./standards/pagination.md)
-* [Data Formats](./standards/data-formats.md)
-* [Operation](./standards/operation.md)
-* [References](./standards/references.md)
+* [Design Principles](design-principles.md)
+* [General Guidelines](general-guidelines.md)
+* [Security](security.md)
+* [Compatibility](compatibility.md)
+* [Deprecation](deprecation.md)
+* [Naming](naming.md)
+* [HTTP](http.md)
+* [Resources](resources.md)
+* [Pagination](pagination.md)
+* [Data Formats](data-formats.md)
+* [Operation](operation.md)
+* [References](references.md)
 
 ## Conventions
 

--- a/api-guidelines/compatibility.md
+++ b/api-guidelines/compatibility.md
@@ -1,0 +1,161 @@
+# MUST Maintain Backward Compatibility
+
+Change APIs, but keep all consumers running. Consumers usually have
+independent release lifecycles, focus on stability, and avoid changes
+that do not provide additional value. APIs are contracts between service
+providers and service consumers that cannot be broken via unilateral
+decisions.
+
+There are two techniques to change APIs without breaking them:
+
+  - follow rules for compatible extensions
+
+  - introduce new API versions and still support older versions
+
+We strongly encourage using compatible API changes and discourage
+versioning. The following guidelines for service providers and consumers
+enable us to make compatible changes without versioning.
+
+**Note:** There is a difference between incompatible and breaking
+changes. Incompatible changes are changes that are not covered by the
+compatibility rules below. Breaking changes are incompatible changes
+deployed into operation, and thereby breaking running API consumers.
+Usually, incompatible changes are breaking changes when deployed into
+operation. However, in specific controlled situations it is possible to
+deploy incompatible changes in a non-breaking way, if no API consumer is
+using the affected API aspects (see also [Deprecation](deprecation.md)).
+
+**Hint:** Please note that the compatibility guarantees are for the "on
+the wire" format. Binary or source compatibility of code generated from
+an API definition is not covered by these rules. If client
+implementations update their generation process to a new version of the
+API definition, it has to be expected that code changes are necessary.
+
+# SHOULD Prefer Compatible Changes
+
+API designers should apply the following rules to evolve RESTful APIs
+for services in a backward-compatible way:
+
+  - Add only optional, never mandatory fields.
+
+  - Never change the semantics of fields (e.g. changing the semantics from
+    customer-number to customer-id, as both are different unique
+    customer keys)
+
+  - Input fields may have (complex) constraints being validated via
+    server-side business logic. Never change the validation logic to be
+    more restrictive and make sure that all constraints are clearly
+    defined in description.
+
+  - Support redirection in case an URL has to change ([301 Moved
+    Permanently](https://en.wikipedia.org/wiki/HTTP_301)).
+
+# MUST Prepare Clients To Not Crash On Compatible API Extensions
+
+Service clients should apply the robustness principle:
+
+  - Be conservative with API requests and data passed as input, e.g.
+    avoid to exploit definition deficits like passing megabytes for
+    strings with unspecified maximum length.
+
+  - Be tolerant in processing and reading data of API responses, more
+    specifically...
+
+Service clients must be prepared for compatible API extensions of
+service providers:
+
+  - Be tolerant with unknown fields in the payload (see also Fowler’s
+    ["TolerantReader"](http://martinfowler.com/bliki/TolerantReader.html)
+    post), i.e. ignore new fields but do not eliminate them from payload
+    if needed for subsequent PUT requests.
+
+  - Be prepared to handle HTTP status codes not explicitly specified in
+    endpoint definitions. Note also, that status codes are extensible.
+    Default handling is how you would treat the corresponding x00 code
+    (see [RFC7231
+    Section 6](https://tools.ietf.org/html/rfc7231#section-6)).
+
+  - Follow the redirect when the server returns HTTP status [301 Moved
+    Permanently](https://en.wikipedia.org/wiki/HTTP_301).
+
+# SHOULD Design APIs Conservatively
+
+Designers of service provider APIs should be conservative and accurate
+in what they accept from clients:
+
+  - Unknown input fields in payload or URL should not be ignored;
+    servers should provide error feedback to clients via an HTTP 400
+    response code.
+
+  - Be accurate in defining input data constraints (like formats,
+    ranges, lengths etc.) — and check constraints and return dedicated
+    error information in case of violations.
+
+  - Prefer being more specific and restrictive (if compliant to
+    functional requirements), e.g. by defining length range of strings.
+    It may simplify implementation while providing freedom for further
+    evolution as compatible extensions.
+
+Not ignoring unknown input fields is a specific deviation from Postel’s
+Law (e.g. see also  
+[The Robustness Principle
+Reconsidered](https://cacm.acm.org/magazines/2011/8/114933-the-robustness-principle-reconsidered/fulltext))
+and a strong recommendation. Servers might want to take a different
+approach but should be aware of the following problems and be explicit
+in what is supported:
+
+  - Ignoring unknown input fields is actually not an option for PUT,
+    since it becomes asymmetric with subsequent GET response and HTTP is
+    clear about the PUT "replace" semantics and default roundtrip
+    expectations (see [RFC7231 Section
+    4.3.4](https://tools.ietf.org/html/rfc7231#section-4.3.4)). Note,
+    accepting (i.e. not ignoring) unknown input fields and returning it
+    in subsequent GET responses is a different situation and compliant
+    to PUT semantics.
+
+  - Certain client errors cannot be recognized by servers, e.g.
+    attribute name typing errors will be ignored without server error
+    feedback. The server cannot differentiate between the client
+    intentionally providing an additional field versus the client
+    sending a mistakenly named field, when the client’s actual intent
+    was to provide an optional input field.
+
+  - Future extensions of the input data structure might be in conflict
+    with already ignored fields and, hence, will not be compatible, i.e.
+    break clients that already use this field but with different type.
+
+In specific situations, where a (known) input field is not needed
+anymore, it either can stay in the API definition with "not used
+anymore" description or can be removed from the API definition as long
+as the server ignores this specific
+parameter.
+
+# SHOULD Avoid Versioning
+
+When changing your RESTful APIs, do so in a compatible way and avoid
+generating additional API versions. Multiple versions can significantly
+complicate understanding, testing, maintaining, evolving, operating and
+releasing our systems ([supplementary
+reading](http://martinfowler.com/articles/enterpriseREST.html)).
+
+If changing an API can’t be done in a compatible way, then proceed in
+one of these three ways:
+
+  - create a new resource (variant) in addition to the old resource
+    variant
+
+  - create a new service endpoint — i.e. a new application with a new
+    API (with a new domain name)
+
+  - create a new API version supported in parallel with the old API by
+    the same microservice
+
+As we discourage versioning by all means because of the manifold
+disadvantages, we strongly recommend to only use the first two
+approaches. Versioning should be a last resort.
+
+# MUST Use URI Versioning
+
+With URI versioning a (major) version number is included in the path,
+e.g. /v1/customers. If you don't put it in at the beginning then it's 
+almost impossible to retro-fit

--- a/api-guidelines/data-formats.md
+++ b/api-guidelines/data-formats.md
@@ -76,7 +76,7 @@ a meaningful value - for example, JSON Merge Patch
 [RFC 7382](https://tools.ietf.org/html/rfc7386)) using null to indicate
 property deletion.
 
-# MUST Empty array values should not be null
+# MUST not use null values for empty array
 
 Empty array values can unambiguously be represented as the empty list,
 `[]`.

--- a/api-guidelines/data-formats.md
+++ b/api-guidelines/data-formats.md
@@ -1,8 +1,85 @@
-# MUST Use JSON:API to Encode Structured Data
+# MUST Use JSON to Encode Structured Data
 
-APIs could represent resources with many different structures, but picking a standard is a good thing.
-[JSON:API](https://jsonapi.org/) is a good approach and enables useful things like including related resources in the same request.
-I tend to prefer a minimal JSON:API implementation to start with and add features if required.
+We use a minimal JSON representation to output objects from the API. This may in the future be extended to use  [JSON:API](https://jsonapi.org/) if the functionality it offers is beneficial, however we are taking the approach of starting simple and extending if necessary. This could be done in a backwards compatible way by representing the same objects in a JSON:API structure as well as the simple JSON structure.
+
+The structure we currently use is:
+
+*A single object*
+A simple collection of attributes and their values. The attributes should be camel-cased.
+
+```JSON
+{
+  "id" : 1,
+  "title" : "A blog post",
+  "body" : "Some useful content"
+}
+```
+
+*A collection of objects*
+This should have a root element matching the pluralised name of the object:
+
+```JSON
+{
+  posts: [
+    {
+      "id" : 1,
+      "title" : "A blog post",
+      "body" : "Some useful content"
+    },
+    {
+      "id" : 2,
+      "title" : "Another blog post",
+      "body" : "More content"
+    }
+  ]
+}
+```
+
+*An error object*
+We use the status code to represent the success or failure of a request. We also pass back an object with more information about the error:
+
+```JSON
+{
+    "status" : "fail",
+    "data" : { "title" : "A title is required" }
+}
+```
+
+# MUST use camelCase property names: `^[a-z][A-Z0-9]*$`
+
+Property names are restricted to ASCII strings. The first character must
+be a letter, or an underscore, and subsequent characters can be a
+letter, or a number.
+
+# MUST pluralise array names
+
+To indicate they contain multiple values we prefer to pluralise array
+names. This implies that object names should in turn be singular.
+
+# MUST Boolean property values must not be null
+
+Schema based JSON properties that are by design booleans must not be
+presented as nulls. A boolean is essentially a closed enumeration of two
+values, true and false. If the content has a meaningful null value,
+strongly prefer to replace the boolean with enumeration of named values
+or statuses - for example acceptedTermsAndConditions with true or
+false can be replaced with termsAndConditions with values yes, no
+and unknown.
+
+# SHOULD Null values should have their fields removed
+
+OpenAPI, which is in common use, doesn’t support null field values (it
+does allow omitting that field completely if it is not marked as
+required). However that doesn’t prevent clients and servers sending and
+receiving those fields with null values. Also, in some cases null may be
+a meaningful value - for example, JSON Merge Patch
+[RFC 7382](https://tools.ietf.org/html/rfc7386)) using null to indicate
+property deletion.
+
+# MUST Empty array values should not be null
+
+Empty array values can unambiguously be represented as the empty list,
+`[]`.
 
 # MAY Use non-JSON Media Types for Binary Data or Alternative Content Representations
 
@@ -87,42 +164,6 @@ components:
           format: int32
           example: 42
 ```
-
-# MUST use camelCase property names: `^[a-z][A-Z0-9]*$`
-
-Property names are restricted to ASCII strings. The first character must
-be a letter, or an underscore, and subsequent characters can be a
-letter, or a number.
-
-# MUST pluralize array names
-
-To indicate they contain multiple values prefer to pluralize array
-names. This implies that object names should in turn be singular.
-
-# MUST Boolean property values must not be null
-
-Schema based JSON properties that are by design booleans must not be
-presented as nulls. A boolean is essentially a closed enumeration of two
-values, true and false. If the content has a meaningful null value,
-strongly prefer to replace the boolean with enumeration of named values
-or statuses - for example acceptedTermsAndConditions with true or
-false can be replaced with termsAndConditions with values yes, no
-and unknown.
-
-# SHOULD Null values should have their fields removed
-
-OpenAPI, which is in common use, doesn’t support null field values (it
-does allow omitting that field completely if it is not marked as
-required). However that doesn’t prevent clients and servers sending and
-receiving those fields with null values. Also, in some cases null may be
-a meaningful value - for example, JSON Merge Patch
-[RFC 7382](https://tools.ietf.org/html/rfc7386)) using null to indicate
-property deletion.
-
-# MUST Empty array values should not be null
-
-Empty array values can unambiguously be represented as the empty list,
-`[]`.
 
 # SHOULD Date property values should conform to RFC 3339
 

--- a/api-guidelines/data-formats.md
+++ b/api-guidelines/data-formats.md
@@ -1,0 +1,182 @@
+# MUST Use JSON:API to Encode Structured Data
+
+APIs could represent resources with many different structures, but picking a standard is a good thing.
+[JSON:API](https://jsonapi.org/) is a good approach and enables useful things like including related resources in the same request.
+I tend to prefer a minimal JSON:API implementation to start with and add features if required.
+
+# MAY Use non-JSON Media Types for Binary Data or Alternative Content Representations
+
+Other media types may be used in following cases:
+
+  - Transferring binary data or data whose structure is not relevant.
+    This is the case if payload structure is not interpreted and
+    consumed by clients as is. Example of such use case is downloading
+    images in formats JPG, PNG, GIF.
+
+  - In addition to JSON version alternative data representations (e.g.
+    in formats PDF, DOC, XML) may be made available through content
+    negotiation.
+
+# MUST Use Standard Date and Time Formats
+
+## JSON Payload
+
+Represent date and time format as [RFC 3339](#should-date-property-values-should-conform-to-rfc-3339).
+
+## HTTP headers
+
+HTTP headers including the proprietary headers use the [HTTP date format defined in RFC 7231](http://tools.ietf.org/html/rfc7231#section-7.1.1.1).
+
+# MAY Use Standards for Country, Language and Currency Codes
+
+Use the following standard formats for country, language and currency
+codes:
+
+  - [ISO 3166-1-alpha2 country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+    
+      - (It is "GB", not "UK", even though "UK" has seen some use at
+        Zalando)
+
+  - [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+    
+      - [BCP-47](https://tools.ietf.org/html/bcp47) (based on ISO 639-1)
+        for language variants
+
+  - [ISO 4217 currency codes](https://en.wikipedia.org/wiki/ISO_4217)
+
+# MUST Define Format for Type Number and Integer
+
+Whenever an API defines a property of type `number` or `integer`, the
+precision must be defined by the format as follows to prevent clients
+from guessing the precision incorrectly, and thereby changing the value
+unintentionally:
+
+| type    | format  | specified value range                                 |
+| ------- | ------- | ----------------------------------------------------- |
+| integer | int32   | integer between -2^31 and 2^31-1                        |
+| integer | int64   | integer between -2^63 and 2^63-1                        |
+| integer | bigint  | arbitrarily large signed integer number               |
+| number  | float   | IEEE 754-2008/ISO 60559:2011 binary64 decimal number  |
+| number  | double  | IEEE 754-2008/ISO 60559:2011 binary128 decimal number |
+| number  | decimal | arbitrarily precise signed decimal number             |
+
+The precision must be translated by clients and servers into the most
+specific language types. E.g. for the following definitions the most
+specific language types in Java will translate to `BigDecimal` for
+`Money.amount` and `int` or `Integer` for the `OrderList.page_size`:
+
+``` yaml
+components:
+  schemas:
+    Money:
+      type: object
+      properties:
+        amount:
+          type: number
+          description: Amount expressed as a decimal number of major currency units
+          format: decimal
+          example: 99.95
+       ...
+
+    OrderList:
+      type: object
+      properties:
+        page_size:
+          type: integer
+          description: Number of orders in list
+          format: int32
+          example: 42
+```
+
+# MUST use camelCase property names: `^[a-z][A-Z0-9]*$`
+
+Property names are restricted to ASCII strings. The first character must
+be a letter, or an underscore, and subsequent characters can be a
+letter, or a number.
+
+# MUST pluralize array names
+
+To indicate they contain multiple values prefer to pluralize array
+names. This implies that object names should in turn be singular.
+
+# MUST Boolean property values must not be null
+
+Schema based JSON properties that are by design booleans must not be
+presented as nulls. A boolean is essentially a closed enumeration of two
+values, true and false. If the content has a meaningful null value,
+strongly prefer to replace the boolean with enumeration of named values
+or statuses - for example acceptedTermsAndConditions with true or
+false can be replaced with termsAndConditions with values yes, no
+and unknown.
+
+# SHOULD Null values should have their fields removed
+
+OpenAPI, which is in common use, doesn’t support null field values (it
+does allow omitting that field completely if it is not marked as
+required). However that doesn’t prevent clients and servers sending and
+receiving those fields with null values. Also, in some cases null may be
+a meaningful value - for example, JSON Merge Patch
+[RFC 7382](https://tools.ietf.org/html/rfc7386)) using null to indicate
+property deletion.
+
+# MUST Empty array values should not be null
+
+Empty array values can unambiguously be represented as the empty list,
+`[]`.
+
+# SHOULD Date property values should conform to RFC 3339
+
+Use the date and time formats defined by
+[RFC 3339](http://tools.ietf.org/html/rfc3339#section-5.6):
+
+  - for "date" use strings matching `date-fullyear "-" date-month "-"
+    date-mday`, for example: `2015-05-28`
+
+  - for "date-time" use strings matching `full-date "T" full-time`, for
+    example `2015-05-28T14:07:17Z`
+
+Note that the [OpenAPI
+format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types)
+"date-time" corresponds to "date-time" in the RFC) and `2015-05-28` for
+a date (note that the OpenAPI format "date" corresponds to "full-date"
+in the RFC). Both are specific profiles, a subset of the international
+standard [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601).
+
+A zone offset may be used (both, in request and responses) — this is
+simply defined by the standards. However, we encourage restricting dates
+to UTC and without offsets. For example `2015-05-28T14:07:17Z` rather
+than `2015-05-28T14:07:17+00:00`. From experience we have learned that
+zone offsets are not easy to understand and often not correctly handled.
+Note also that zone offsets are different from local times that might be
+including daylight saving time. Localization of dates should be done by
+the services that provide user interfaces, if required.
+
+When it comes to storage, all dates should be consistently stored in UTC
+without a zone offset. Localization should be done locally by the
+services that provide user interfaces, if required.
+
+Sometimes it can seem data is naturally represented using numerical
+timestamps, but this can introduce interpretation issues with precision
+- for example whether to represent a timestamp as 1460062925,
+1460062925000 or 1460062925.000. Date strings, though more verbose and
+requiring more effort to parse, avoid this ambiguity.
+
+# SHOULD Time durations and intervals could conform to ISO 8601
+
+Schema based JSON properties that are by design durations and intervals
+could be strings formatted as recommended by ISO 8601 ([Appendix A of
+RFC 3339 contains a
+grammar](https://tools.ietf.org/html/rfc3339#appendix-A) for durations).
+
+# SHOULD Use standards for Language, Country and Currency
+
+  - [ISO 3166-1-alpha2
+    country](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+
+  - [ISO 639-1 language
+    code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+
+  - [BCP-47](https://tools.ietf.org/html/bcp47) (based on ISO 639-1) for
+    language variants
+
+  - [ISO 4217 currency codes](http://en.wikipedia.org/wiki/ISO_4217)

--- a/api-guidelines/deprecation.md
+++ b/api-guidelines/deprecation.md
@@ -1,0 +1,65 @@
+Sometimes it is necessary to phase out an API endpoint (or version), for
+instance, if a field is no longer supported in the result or a whole
+business functionality behind an endpoint has to be shut down. There are
+many other reasons as well. As long as these endpoints are still used by
+consumers these are breaking changes and not allowed. Deprecation rules
+have to be applied to make sure that necessary consumer changes are
+aligned and deprecated endpoints are not used before API changes are
+deployed.
+
+# MUST Obtain Approval of Clients
+
+Before shutting down an API (or version of an API) the producer must
+make sure that all clients have given their consent to shut down the
+endpoint. Producers should help consumers migrate to a new
+endpoint (i.e. by providing a migration manual). After all clients are
+migrated, the producer may shut down the deprecated API.
+
+# MUST External Partners Must Agree on Deprecation Timespan
+
+If the API is consumed by any external partner, the producer must define
+a reasonable timespan that the API will be maintained after the producer
+has announced deprecation. The external partner (client) must agree to
+this minimum after-deprecation-lifespan before he starts using the API.
+
+# MUST Reflect Deprecation in API Definition
+
+API deprecation must be part of the OpenAPI definition. If a method on a
+path, a whole path or even a whole API endpoint (multiple paths) should
+be deprecated, the producers must set `deprecated=true` on each method /
+path element that will be deprecated. If deprecation should happen on a
+more fine grained level (i.e. query parameter, payload etc.), the
+producer should set `deprecated=true` on the affected method / path
+element and add further explanation to the `description` section.
+
+If `deprecated` is set to `true`, the producer must describe what
+clients should use instead and when the API will be shut down in the
+`description` section of the API definition.
+
+# MUST Monitor Usage of Deprecated APIs
+
+Owners of APIs used in production must monitor usage of deprecated APIs
+until the API can be shut down in order to align deprecation and avoid
+uncontrolled breaking effects.
+
+# SHOULD Add a Warning Header to Responses
+
+During deprecation phase, the producer should add a `Warning` header
+(see [RFC 7234 - Warning
+header](https://tools.ietf.org/html/rfc7234#section-5.5)) field. When
+adding the `Warning` header, the `warn-code` must be `299` and the
+`warn-text` should be in form of *"The path/operation/parameter/…​
+{name} is deprecated and will be removed by {date}. Please see {link}
+for details."* with a link to a documentation describing why the API is
+no longer supported in the current form and what clients should do about
+it. Adding the `Warning` header is not sufficient to gain client consent
+to shut down an API.
+
+# SHOULD Add Monitoring for Warning Header
+
+Clients should monitor the `Warning` header in HTTP responses to see if
+an API will be deprecated in future.
+
+# MUST Not Start Using Deprecated APIs
+
+Clients must not start using deprecated parts of an API.

--- a/api-guidelines/deprecation.md
+++ b/api-guidelines/deprecation.md
@@ -15,7 +15,7 @@ endpoint. Producers should help consumers migrate to a new
 endpoint (i.e. by providing a migration manual). After all clients are
 migrated, the producer may shut down the deprecated API.
 
-# MUST External Partners Must Agree on Deprecation Timespan
+# MUST Agree Deprecation Timespan with External Partners
 
 If the API is consumed by any external partner, the producer must define
 a reasonable timespan that the API will be maintained after the producer

--- a/api-guidelines/design-principles.md
+++ b/api-guidelines/design-principles.md
@@ -1,0 +1,126 @@
+# API Design Principles
+
+Comparing SOA web service interfacing style of SOAP vs. REST, the former
+tend to be centered around operations that are usually use-case specific
+and specialized. In contrast, REST is centered around business (data)
+entities exposed as resources that are identified via URIs and can be
+manipulated via standardized CRUD-like methods using different
+representations, and hypermedia. RESTful APIs tend to be less use-case
+specific and comes with less rigid client / server coupling and are more
+suitable for an ecosystem of (core) services providing a platform of
+APIs to build diverse new business services. We apply the RESTful web
+service principles to all kind of application (micro-) service
+components, independently from whether they provide functionality via
+the internet or intranet.
+
+  - We prefer REST-based APIs with JSON payloads.
+
+An important principle for API design and usage is Postel’s Law, aka
+[The Robustness
+Principle](http://en.wikipedia.org/wiki/Robustness_principle) (see also
+[RFC 1122](https://tools.ietf.org/html/rfc1122)):
+
+  - Be liberal in what you accept, be conservative in what you send
+
+*Readings:* Some interesting reads on the RESTful API design style and
+service architecture:
+
+  - Book: [Irresistable APIs: Designing web APIs that developers will
+    love](https://www.amazon.de/Irresistible-APIs-Designing-that-developers/dp/1617292559)
+
+  - Book: [REST in Practice: Hypermedia and Systems
+    Architecture](http://www.amazon.de/REST-Practice-Hypermedia-Systems-Architecture/dp/0596805829)
+
+  - Book: [Build APIs You Won’t
+    Hate](https://leanpub.com/build-apis-you-wont-hate)
+
+  - InfoQ eBook: [Web APIs: From Start to
+    Finish](http://www.infoq.com/minibooks/emag-web-api)
+
+  - Lessons-learned blog: [Thoughts on RESTful API
+    Design](http://restful-api-design.readthedocs.org/en/latest/)
+
+  - Fielding Dissertation: [Architectural Styles and the Design of
+    Network-Based Software
+    Architectures](http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm)
+
+# Designing APIs
+
+APIs should adhere to the same design principles as any well managed product:
+
+  - Treat your API as product and act like a product owner
+
+  - Put yourself into the place of your customers; be an advocate for
+    their needs
+
+  - Emphasize simplicity, comprehensibility, and usability of APIs to
+    make them irresistible for client engineers
+
+  - Actively improve and maintain API consistency over the long term
+
+  - Make use of customer feedback and provide service level support
+
+Understand the concrete use cases of your API consumers and carefully check
+the trade-offs of your API design variants with a product mindset. Avoid
+short-term implementation optimizations at the expense of unnecessary
+client side obligations, and have a high attention on API quality and
+client developer experience.
+
+# API First
+
+API First is one of our principles. In a nutshell API First requires two aspects:
+
+  - define APIs first, before coding its implementation, using a
+    standard specification language
+
+  - get early review feedback from peers and client developers
+
+By defining APIs outside the code, we want to facilitate early review
+feedback and also a development discipline that focus service interface
+design on...
+
+  - profound understanding of the domain and required functionality
+
+  - generalized business entities / resources, i.e. avoidance of use
+    case specific APIs
+
+  - clear separation of WHAT vs. HOW concerns, i.e. abstraction from
+    implementation aspects — APIs should be stable even if we replace
+    complete service implementation including its underlying technology
+    stack
+
+Moreover, API definitions with standardized specification format also
+facilitate...
+
+  - single source of truth for the API specification; it is a crucial
+    part of a contract between service provider and client users
+
+  - infrastructure tooling for API discovery, API GUIs, API documents,
+    automated quality checks
+
+Elements of API First are also these standards and a standardized
+API review process (TBC) as to get early review feedback from peers and client
+developers. Peer review is important for us to get high quality APIs, to
+enable architectural and design alignment and to supported development
+of client applications decoupled from service provider engineering life
+cycle.
+
+It is important to learn, that API First is **not in conflict with the
+agile development principles** that we love. Applications should
+evolve incrementally — and so its APIs. Of course, our API specification
+will and should evolve iteratively in different cycles; however, each
+starting with draft status and *early* team and peer review feedback.
+API may change and profit from implementation concerns and automated
+testing feedback. API evolution during development life cycle may
+include breaking changes for not yet productive features and as long as
+we have aligned the changes with the clients. Hence, API First does
+*not* mean that you must have 100% domain and requirement understanding
+and can never produce code before you have defined the complete API and
+get it confirmed by peer review. On the other hand, API First obviously
+is in conflict with the bad practice of publishing API definition and
+asking for peer review after the service integration or even the service
+productive operation has started. It is crucial to request and get early
+feedback — as early as possible, but not before the API changes are
+comprehensive with focus to the next evolution step and have a certain
+quality (including API Guideline compliance), already confirmed via team
+internal reviews.

--- a/api-guidelines/general-guidelines.md
+++ b/api-guidelines/general-guidelines.md
@@ -1,0 +1,43 @@
+# MUST Follow API First Principle
+
+You must follow the [API First Principle](design-principles.md#api-first), more
+specifically:
+
+  - You must define APIs first, before coding its implementation, [using
+    OpenAPI as specification language](#must-provide-api-specification-using-openapi)
+
+  - You must design your APIs consistently with this guidelines
+
+  - You must call for early review feedback from peers and client
+    developers
+
+# MUST Provide API Specification using OpenAPI
+
+We use the [OpenAPI specification v3.0](https://www.openapis.org) as
+standard to define API specifications files. API designers have to
+provide the API specification files using **YAML** to improve
+readability.
+
+The API specification files should be subject to version control using a
+source code management system - best together with the implementing
+sources.
+
+You MUST publish the API specification with the deployment of the
+implementing service.
+
+# MAY Provide API User Guide
+
+In addition to the API Specification, if the API is expected to be widely
+used, it is good practice to provide an
+API user guide to improve client developer experience, especially for
+engineers that are less experienced in using this API. A helpful API
+user guide typically describes the following API aspects:
+
+  - API scope, purpose, and use cases
+
+  - concrete examples of API usage
+
+  - edge cases, error situation details, and repair hints
+
+  - architecture context and major dependencies - including figures and
+    sequence flows

--- a/api-guidelines/http.md
+++ b/api-guidelines/http.md
@@ -150,30 +150,6 @@ depending on how the resource is represented after deletion. Under no
 circumstances the resource must be accessible after this operation on
 its endpoint.
 
-## HEAD
-
-HEAD requests are used to **retrieve** the header information of single
-resources and resource collections.
-
-  - HEAD has exactly the same semantics as GET, but returns headers
-    only, no body.
-
-## OPTIONS
-
-OPTIONS requests are used to **inspect** the available operations (HTTP
-methods) of a given endpoint.
-
-  - OPTIONS responses usually either return a comma separated list of
-    methods in the `Allow` header or as a structured list of link
-    templates
-
-**Note:** OPTIONS is rarely implemented, though it could be used to
-self-describe the full functionality of a resource.
-
-This section describes a handful of headers, which we found raised the
-most questions in our daily usage, or which are useful in particular
-circumstances but not widely known.
-
 # MUST Use Content Headers Correctly
 
 Content or entity headers are headers with a `Content-` prefix. They
@@ -228,8 +204,6 @@ Method implementations must fulfill the following basic properties:
 
 | HTTP method | safe | idempotent |
 | ----------- | ---- | ---------- |
-| OPTIONS     | Yes  | Yes        |
-| HEAD        | Yes  | Yes        |
 | GET         | Yes  | Yes        |
 | PUT         | No   | Yes        |
 | POST        | No   | No         |
@@ -296,7 +270,7 @@ responses:
     content:
       "application/problem+json":
         schema:
-          $ref: 'https://zalando.github.io/problem/schema.yaml#/Problem'
+          $ref: 'https://github.io/problem/schema.yaml#/Problem'
 ```
 
 API designers should also think about a **troubleshooting board** as
@@ -360,15 +334,9 @@ response.
 | 401  | Unauthorized - the users must log in (this often means "Unauthenticated")                                                                                     | All                      |
 | 403  | Forbidden - the user is not authorized to use this resource                                                                                                   | All                      |
 | 404  | Not found - the resource is not found                                                                                                                         | All                      |
-| 405  | Method Not Allowed - the method is not supported, see OPTIONS                                                                                                 | All                      |
+| 405  | Method Not Allowed - the method is not supported                                                                                                 | All                      |
 | 406  | Not Acceptable - resource can only generate content not acceptable according to the Accept headers sent in the request                                        | All                      |
-| 408  | Request timeout - the server times out waiting for the resource                                                                                               | All                      |
-| 409  | Conflict - request cannot be completed due to conflict, e.g. when two clients try to create the same resource or if there are concurrent, conflicting updates | POST, PUT, DELETE, PATCH |
-| 410  | Gone - resource does not exist any longer, e.g. when accessing a resource that has intentionally been deleted                                                 | All                      |
-| 412  | Precondition Failed - returned for conditional requests, e.g. If-Match if the condition failed. Used for optimistic locking.                                  | PUT, DELETE, PATCH       |
 | 415  | Unsupported Media Type - e.g. clients sends request body without content type                                                                                 | POST, PUT, DELETE, PATCH |
-| 423  | Locked - Pessimistic locking, e.g. processing states                                                                                                          | PUT, DELETE, PATCH       |
-| 428  | Precondition Required - server requires the request to be conditional (e.g. to make sure that the "lost update problem" is avoided).                          | All                      |
 | 429  | Too many requests - the client does not consider rate limiting and sent too many requests. See [MUST Use Code 429 with Headers for Rate Limits](#153).      | All                      |
 
 ## Server Side Error Codes:
@@ -376,7 +344,6 @@ response.
 | Code | Meaning                                                                                                                                                                                                                                                                                                                               | Methods |
 | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | 500  | Internal Server Error - a generic error indication for an unexpected server execution problem (here, client retry may be sensible)                                                                                                                                                                                                    | All     |
-| 501  | Not Implemented - server cannot fulfill the request (usually implies future availability, e.g. new feature).                                                                                                                                                                                                                          | All     |
 | 503  | Service Unavailable - service is (temporarily) not available (e.g. if a required component or downstream service is not available) — client retry may be sensible. If possible, the service should indicate how long the client should wait by setting the ['Retry-After'](https://tools.ietf.org/html/rfc7231#section-7.1.3) header. | All     |
 
 # MUST Use Most Specific HTTP Status Codes

--- a/api-guidelines/http.md
+++ b/api-guidelines/http.md
@@ -1,0 +1,461 @@
+# MUST Use REST Maturity Level 2
+
+We strive for a good implementation of [REST Maturity Level 2](http://martinfowler.com/articles/richardsonMaturityModel.html#level2)
+as it enables us to build resource-oriented APIs that make full use of
+HTTP verbs and status codes. You can see this expressed by many rules
+throughout these guidelines, e.g.:
+
+  - [Avoid Actions — Think About Resources](resources.md#must-avoid-actions--think-about-resources)
+
+  - [MUST Keep URLs Verb-Free](resources.md#must-keep-urls-verb-free)
+
+  - [MUST Use HTTP Methods Correctly](#must-use-http-methods-correctly)
+
+  - [MUST Use Standard HTTP Status Codes](#must-use-standard-http-status-codes)
+  
+# MUST Use HTTP Methods Correctly
+
+Be compliant with the standardized HTTP method semantics summarized as follows:
+
+## GET
+
+GET requests are used to **read** either a single or a collection resource.
+
+  - GET requests for individual resources will usually generate a 404 if the resource does not exist
+
+  - GET requests for collection resources may return either 200 (if the collection is empty) or 404 (if the collection is missing)
+
+  - GET requests must NOT have a request body payload
+
+**Note:** GET requests on collection resources should provide sufficient
+filter and [pagination](pagination.md) mechanisms.
+
+## PUT
+
+PUT requests are used to **update entire** resources. The semantic is best
+described as *"please put the enclosed representation at the resource
+mentioned by the URL, replacing any existing resource."*.
+
+  - PUT requests are usually applied to single resources, and not to
+    collection resources, as this would imply replacing the entire
+    collection
+
+  - PUT requests are usually robust against non-existence of resources
+    by implicitly creating before updating
+
+  - on successful PUT requests, the server will **replace the entire
+    resource** addressed by the URL with the representation passed in
+    the payload (subsequent reads will deliver the same payload)
+
+  - successful PUT requests will usually generate 200 or 204 (if the
+    resource was updated - with or without actual content returned), and
+    201 (if the resource was created)
+
+## POST
+
+POST requests are idiomatically used to **create** single resources on a
+collection resource endpoint, but other semantics on single resources
+endpoint are possible. The semantic for collection endpoints is
+best described as *"please add the enclosed representation to the
+collection resource identified by the URL"*.
+
+  - on a successful POST request, the server will create one or multiple
+    new resources and provide their URI/URLs in the response
+
+  - successful POST requests will usually generate 200 (if resources
+    have been updated), 201 (if resources have been created), and 202
+    (if the request was accepted but has not been finished yet)
+
+The semantic for single resource endpoints is best described as *"please
+execute the given well specified request on the resource identified by
+the URL"*.
+
+**Generally:** POST should be used for scenarios that cannot be covered
+by the other methods sufficiently. In such cases, make sure to document
+the fact that POST is used as a workaround.
+
+**Note:** Resource IDs with respect to POST requests are created and
+maintained by server and returned with response payload.
+
+**Tip:** Posting the same resource twice is by itself **not** required
+to be *idempotent* and may result in multiple resource instances.
+
+## PATCH
+
+PATCH requests are used to **update parts** of single resources, i.e.
+where only a specific subset of resource fields should be replaced. The
+semantic is best described as *"please change the resource identified by
+the URL according to my change request"*. The semantic of the change
+request is not defined in the HTTP standard and must be described in the
+API specification by using suitable media types.
+
+  - PATCH requests are usually applied to single resources as patching
+    entire collection is challenging
+
+  - PATCH requests are usually not robust against non-existence of
+    resource instances
+
+  - on successful PATCH requests, the server will update parts of the
+    resource addressed by the URL as defined by the change request in
+    the payload
+
+  - successful PATCH requests will usually generate 200 or 204 (if
+    resources have been updated with or without updated content
+    returned)
+
+**Note (To Be Clarified):** since implementing PATCH correctly is a bit tricky, we
+strongly suggest to choose one and only one of the following patterns per endpoint.
+
+1.  use PUT with complete objects to update a resource as long as
+    feasible (i.e. do not use PATCH at all).
+
+2.  use PATCH with partial objects to only update parts of a resource,
+    whenever possible. (This is basically [JSON Merge Patch](https://tools.ietf.org/html/rfc7396),
+    a specialized media type `application/merge-patch+json` that is a partial resource
+    representation.)
+
+3.  use PATCH with [JSON Patch](http://tools.ietf.org/html/rfc6902), a
+    specialized media type `application/json-patch+json` that includes
+    instructions on how to change the resource.
+
+4.  use POST (with a proper description of what is happening) instead of
+    PATCH, if the request does not modify the resource in a way defined
+    by the semantics of the media type.
+
+In practice [JSON Merge Patch](https://tools.ietf.org/html/rfc7396)
+quickly turns out to be too limited, especially when trying to update
+single objects in large collections (as part of the resource). In this
+cases [JSON Patch](http://tools.ietf.org/html/rfc6902) can shown its
+full power while still showing readable patch requests (see also 
+[JSON patch vs. merge](http://erosb.github.io/post/json-patch-vs-merge-patch)).
+
+## DELETE
+
+DELETE requests are used to **delete** resources. The semantic is best
+described as *"please delete the resource identified by the URL"*.
+
+  - DELETE requests are usually applied to single resources, not on
+    collection resources, as this would imply deleting the entire
+    collection
+
+  - successful DELETE requests will usually generate 200 (if the deleted
+    resource is returned) or 204 (if no content is returned)
+
+  - failed DELETE requests will usually generate 404 (if the resource
+    cannot be found) or 410 (if the resource was already deleted before)
+
+**Important:** After deleting a resource with DELETE, a GET request on
+the resource is expected to either return 404 (not found) or 410 (gone)
+depending on how the resource is represented after deletion. Under no
+circumstances the resource must be accessible after this operation on
+its endpoint.
+
+## HEAD
+
+HEAD requests are used to **retrieve** the header information of single
+resources and resource collections.
+
+  - HEAD has exactly the same semantics as GET, but returns headers
+    only, no body.
+
+## OPTIONS
+
+OPTIONS requests are used to **inspect** the available operations (HTTP
+methods) of a given endpoint.
+
+  - OPTIONS responses usually either return a comma separated list of
+    methods in the `Allow` header or as a structured list of link
+    templates
+
+**Note:** OPTIONS is rarely implemented, though it could be used to
+self-describe the full functionality of a resource.
+
+This section describes a handful of headers, which we found raised the
+most questions in our daily usage, or which are useful in particular
+circumstances but not widely known.
+
+# MUST Use Content Headers Correctly
+
+Content or entity headers are headers with a `Content-` prefix. They
+describe the content of the body of the message and they can be used in
+both, HTTP requests and responses. Commonly used content headers include
+but are not limited to:
+
+  - [`Content-Disposition`](https://tools.ietf.org/html/rfc6266) can
+    indicate that the representation is supposed to be saved as a file,
+    and the proposed file
+    name.
+
+  - [`Content-Encoding`](https://tools.ietf.org/html/rfc7231#section-3.1.2.2)
+    indicates compression or encryption algorithms applied to the
+    content.
+
+  - [`Content-Length`](https://tools.ietf.org/html/rfc7230#section-3.3.2)
+    indicates the length of the content (in
+    bytes).
+
+  - [`Content-Language`](https://tools.ietf.org/html/rfc7231#section-3.1.3.2)
+    indicates that the body is meant for people literate in some human
+    language(s).
+
+  - [`Content-Location`](https://tools.ietf.org/html/rfc7231#section-3.1.4.2)
+    indicates where the body can be found otherwise.
+
+  - [`Content-Range`](https://tools.ietf.org/html/rfc7233#section-4.2)
+    is used in responses to range requests to indicate which part of the
+    requested resource representation is delivered with the
+    body.
+
+  - [`Content-Type`](https://tools.ietf.org/html/rfc7231#section-3.1.1.5)
+    indicates the media type of the body content.
+
+# MAY Use Other Standardized Headers
+
+Use [this list](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields)
+and mention its support in your OpenAPI definition.
+
+# MUST Fulfill Safeness and Idempotency Properties
+
+An operation can be...
+
+  - idempotent, i.e. operation will have the same effect on the server’s
+    state if executed once or multiple times (note: this does not
+    necessarily mean returning the same response or status code)
+
+  - safe, i.e. must not have side effects such as state changes
+
+Method implementations must fulfill the following basic properties:
+
+| HTTP method | safe | idempotent |
+| ----------- | ---- | ---------- |
+| OPTIONS     | Yes  | Yes        |
+| HEAD        | Yes  | Yes        |
+| GET         | Yes  | Yes        |
+| PUT         | No   | Yes        |
+| POST        | No   | No         |
+| DELETE      | No   | Yes        |
+| PATCH       | No   | No         |
+
+# SHOULD Define Collection Format of Query Parameters and Headers
+
+Sometimes, query parameters and headers may allow users to provide a list of
+values by providing a comma-separated list (`csv`).
+The API specification should explicitly define the type as follows:
+
+| Description            | OpenAPI 3.0                   | Example                      |
+| ---------------------- | ----------------------------- | ---------------------------- |
+| Comma separated values | `style: form, explode: false` | `?param=value1,value2`       |
+
+# MUST Document Implicit Filtering
+
+Sometimes certain collection resources or queries will not list all the
+possible elements they have, but only those for which the current client
+is authorized to access.
+
+Implicit filtering could be done on:
+
+  - the collection of resources being returned on a parent `GET` request
+
+  - the fields returned for the resource’s detail
+
+In such cases, the implicit filtering must be in the API Specification
+(in its description):
+
+``` yaml
+paths:
+  /business-partner:
+    get:
+      description: >-
+        Get the list of registered business partner.
+        Only the business partners to which you have access to are returned.
+```
+
+# MUST Specify Success and Error Responses
+
+APIs should define the functional, business view and abstract from
+implementation aspects. Success and error responses are a vital part to
+define how an API is used correctly.
+
+Therefore, you must define **all** success and service specific error
+responses in your API specification. Both are part of the interface
+definition and provide important information for service clients to
+handle standard as well as exceptional situations.
+
+**Hint:** In most cases it is not useful to document all technical
+errors, especially if they are not under control of the service
+provider. Thus unless a response code conveys application-specific
+functional semantics or is used in a none standard way that requires
+additional explanation, multiple error response specifications can be
+combined using the following pattern:
+
+``` yaml
+responses:
+  ...
+  default:
+    description: error occurred - see status code and problem object for more information.
+    content:
+      "application/problem+json":
+        schema:
+          $ref: 'https://zalando.github.io/problem/schema.yaml#/Problem'
+```
+
+API designers should also think about a **troubleshooting board** as
+part of the associated online API documentation. It provides information
+and handling guidance on application-specific errors and is referenced
+via links from the API specification. This can reduce service support
+tasks and contribute to service client and provider performance.
+
+# MUST Use Standard HTTP Status Codes
+
+You must only use standardized HTTP status codes consistently with their
+intended semantics. You must not invent new HTTP status codes.
+
+RFC standards define \~60 different HTTP status codes with specific
+semantics (mainly
+[RFC7231](https://tools.ietf.org/html/rfc7231#section-6) and
+[RFC-6585](https://tools.ietf.org/html/rfc6585)) — and there are
+upcoming new ones, e.g. [draft legally-restricted-status](https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-05).
+See overview on all error codes on
+[Wikipedia](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) or
+via <https://httpstatuses.com/>) also inculding 'unofficial codes', e.g.
+used by popular web servers like Nginx.
+
+Below we list the most commonly used and best understood HTTP status
+codes, consistent with their semantics in the RFCs. APIs should only use
+these to prevent misconceptions that arise from less commonly used HTTP
+status codes.
+
+**Important:** As long as your HTTP status code usage is well covered by
+the semantic defined here, you should not describe it to avoid an
+overload with common sense information and the risk of inconsistent
+definitions. Only if the HTTP status code is not in the list below or
+its usage requires additional information aside the well defined
+semantic, the API specification must provide a clear description of the
+HTTP status code in the
+response.
+
+## Success Codes
+
+| Code | Meaning                                                                                                                                                                                                                                                  | Methods                  |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 200  | OK - this is the standard success response                                                                                                                                                                                                               | All                      |
+| 201  | Created - Returned on successful entity creation. You are free to return either an empty response or the created resource in conjunction with the Location header. (More details found in [common headers](#must-use-content-headers-correctly).) *Always* set the Location header. | POST, PUT                |
+| 202  | Accepted - The request was successful and will be processed asynchronously.                                                                                                                                                                              | POST, PUT, DELETE, PATCH |
+| 204  | No content - There is no response body                                                                                                                                                                                                                   | PUT, DELETE, PATCH       |
+| 207  | Multi-Status - The response body contains multiple status informations for different parts of a batch/bulk request. See [MUST Use Code 207 for Batch or Bulk Requests](#must-use-code-207-for-batch-or-bulk-requests).                                                                          | POST                     |
+
+## Redirection Codes
+
+| Code | Meaning                                                                                                                                | Methods                  |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 301  | Moved Permanently - This and all future requests should be directed to the given URI.                                                  | All                      |
+| 303  | See Other - The response to the request can be found under another URI using a GET method.                                             | PATCH, POST, PUT, DELETE |
+| 304  | Not Modified - resource has not been modified since the date or version passed via request headers If-Modified-Since or If-None-Match. | GET                      |
+
+## Client Side Error Codes
+
+| Code | Meaning                                                                                                                                                       | Methods                  |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| 400  | Bad request - generic / unknown error. Should also be delivered in case of input payload fails business logic validation.                                     | All                      |
+| 401  | Unauthorized - the users must log in (this often means "Unauthenticated")                                                                                     | All                      |
+| 403  | Forbidden - the user is not authorized to use this resource                                                                                                   | All                      |
+| 404  | Not found - the resource is not found                                                                                                                         | All                      |
+| 405  | Method Not Allowed - the method is not supported, see OPTIONS                                                                                                 | All                      |
+| 406  | Not Acceptable - resource can only generate content not acceptable according to the Accept headers sent in the request                                        | All                      |
+| 408  | Request timeout - the server times out waiting for the resource                                                                                               | All                      |
+| 409  | Conflict - request cannot be completed due to conflict, e.g. when two clients try to create the same resource or if there are concurrent, conflicting updates | POST, PUT, DELETE, PATCH |
+| 410  | Gone - resource does not exist any longer, e.g. when accessing a resource that has intentionally been deleted                                                 | All                      |
+| 412  | Precondition Failed - returned for conditional requests, e.g. If-Match if the condition failed. Used for optimistic locking.                                  | PUT, DELETE, PATCH       |
+| 415  | Unsupported Media Type - e.g. clients sends request body without content type                                                                                 | POST, PUT, DELETE, PATCH |
+| 423  | Locked - Pessimistic locking, e.g. processing states                                                                                                          | PUT, DELETE, PATCH       |
+| 428  | Precondition Required - server requires the request to be conditional (e.g. to make sure that the "lost update problem" is avoided).                          | All                      |
+| 429  | Too many requests - the client does not consider rate limiting and sent too many requests. See [MUST Use Code 429 with Headers for Rate Limits](#153).      | All                      |
+
+## Server Side Error Codes:
+
+| Code | Meaning                                                                                                                                                                                                                                                                                                                               | Methods |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| 500  | Internal Server Error - a generic error indication for an unexpected server execution problem (here, client retry may be sensible)                                                                                                                                                                                                    | All     |
+| 501  | Not Implemented - server cannot fulfill the request (usually implies future availability, e.g. new feature).                                                                                                                                                                                                                          | All     |
+| 503  | Service Unavailable - service is (temporarily) not available (e.g. if a required component or downstream service is not available) — client retry may be sensible. If possible, the service should indicate how long the client should wait by setting the ['Retry-After'](https://tools.ietf.org/html/rfc7231#section-7.1.3) header. | All     |
+
+# MUST Use Most Specific HTTP Status Codes
+
+You must use the most specific HTTP status code when returning
+information about your request processing status or error situations.
+
+# MUST Use Code 207 for Batch or Bulk Requests
+
+Some APIs are required to provide either *batch* or *bulk* requests
+using POST for performance reasons, i.e. for communication and
+processing efficiency. In this case services may be in need to signal
+multiple response codes for each part of an batch or bulk request. As
+HTTP does not provide proper guidance for handling batch/bulk requests
+and responses, we herewith define the following approach:
+
+  - A batch or bulk request **always** has to respond with HTTP status
+    code **207**, unless it encounters a generic or unexpected failure
+    before looking at individual parts.
+
+  - A batch or bulk response with status code 207 **always** returns a
+    multi-status object containing sufficient status and/or monitoring
+    information for each part of the batch or bulk request.
+
+  - A batch or bulk request may result in a status code 400/500, only if
+    the service encounters a failure before looking at individual parts
+    or, if an unanticipated failure occurs.
+
+The before rules apply *even in the case* that processing of all
+individual part *fail* or each part is executed *asynchronously*\! They
+are intended to allow clients to act on batch and bulk responses by
+inspecting the individual results in a consistent way.
+
+**Note**: while a *batch* defines a collection of requests triggering
+independent processes, a *bulk* defines a collection of independent
+resources created or updated together in one request. With respect to
+response processing this distinction normally does not matter.
+
+# MUST Use Code 429 with Headers for Rate Limits
+
+APIs that wish to manage the request rate of clients must use the ['429
+Too Many Requests'](http://tools.ietf.org/html/rfc6585) response code if
+the client exceeded the request rate and therefore the request can’t be
+fulfilled. Such responses must also contain header information providing
+further details to the client. There are two approaches a service can
+take for header information:
+
+  - Return a ['Retry-After'](https://tools.ietf.org/html/rfc7231#section-7.1.3)
+    header indicating how long the client ought to wait before making a
+    follow-up request. The Retry-After header can contain a HTTP date
+    value to retry after or the number of seconds to delay. Either is
+    acceptable but APIs should prefer to use a delay in seconds.
+
+  - Return a trio of 'X-RateLimit' headers. These headers (described
+    below) allow a server to express a service level in the form of a
+    number of allowing requests within a given window of time and when
+    the window is reset.
+
+The 'X-RateLimit' headers are:
+
+  - `X-RateLimit-Limit`: The maximum number of requests that the client
+    is allowed to make in this window.
+
+  - `X-RateLimit-Remaining`: The number of requests allowed in the
+    current window.
+
+  - `X-RateLimit-Reset`: The relative time in seconds when the rate
+    limit window will be reset. **Beware** that this is different to
+    Github and Twitter’s usage of a header with the same name which is
+    using UTC epoch seconds instead.
+
+The reason to allow both approaches is that APIs can have different
+needs. Retry-After is often sufficient for general load handling and
+request throttling scenarios and notably, does not strictly require the
+concept of a calling entity such as a tenant or named account. In turn
+this allows resource owners to minimise the amount of state they have to
+carry with respect to client requests. The 'X-RateLimit' headers are
+suitable for scenarios where clients are associated with pre-existing
+account or tenancy structures. 'X-RateLimit' headers are generally
+returned on every request and not just on a 429, which implies the
+service implementing the API is carrying sufficient state to track the
+number of requests made within a given window for each named entity.

--- a/api-guidelines/naming.md
+++ b/api-guidelines/naming.md
@@ -22,14 +22,6 @@ Usually, a collection of resource instances is provided (at least API
 should be ready here). The special case of a resource singleton is a
 collection with cardinality 1.
 
-# MAY Use /api as first Path Segment
-
-In most cases, all resources provided by a service are part of the
-public API, and therefore should be made available under the root "/"
-base path. If the service should also support non-public, internal APIs
-— for specific operational support functions, for example — add "/api"
-as base path to clearly separate public and non-public API resources.
-
 # MUST Avoid Trailing Slashes
 
 The trailing slash must not have specific semantics. Resource paths must

--- a/api-guidelines/naming.md
+++ b/api-guidelines/naming.md
@@ -1,0 +1,61 @@
+# MUST Use lowercase separate words with hyphens for Path Segments
+
+Example:
+
+``` http
+/shipment-orders/{shipment-order-id}
+```
+
+This applies to concrete path segments and not the names of path
+parameters. For example `{shipment_order_id}` would be ok as a path
+parameter.
+
+# MUST Use snake_case for Query Parameters
+
+Examples:
+
+    customer_number, order_id, billing_address
+
+# MUST Pluralize Resource Names
+
+Usually, a collection of resource instances is provided (at least API
+should be ready here). The special case of a resource singleton is a
+collection with cardinality 1.
+
+# MAY Use /api as first Path Segment
+
+In most cases, all resources provided by a service are part of the
+public API, and therefore should be made available under the root "/"
+base path. If the service should also support non-public, internal APIs
+— for specific operational support functions, for example — add "/api"
+as base path to clearly separate public and non-public API resources.
+
+# MUST Avoid Trailing Slashes
+
+The trailing slash must not have specific semantics. Resource paths must
+deliver the same results whether they have the trailing slash or not.
+
+# MUST Stick to Conventional Query Parameters
+
+If you provide query support for searching, sorting, filtering, and
+paginating, you must stick to the following naming conventions:
+
+  - `q` — default query parameter (e.g. used by browser tab completion);
+    should have an entity specific alias, like sku
+
+  - `sort` — comma-separated list of fields
+    to define the sort order. To indicate sorting direction, fields may
+    be prefixed with `+` (ascending) or `-` (descending), e.g.
+    /sales-orders?sort=+id
+
+  - `fields` — to retrieve only a subset of fields of a resource.
+
+  - `embed` — to expand or embed sub-entities (ie.: inside of an
+    article entity, expand silhouette code into the silhouette object).
+    Implementing `embed` correctly is difficult, so do it with care.
+
+  - `offset` — numeric offset of the first element on a page. See
+    [pagination](pagination.md) section.
+
+  - `limit` — client suggested limit to restrict the number of entries
+    on a page. See [pagination](pagination.md) section.

--- a/api-guidelines/operation.md
+++ b/api-guidelines/operation.md
@@ -1,0 +1,5 @@
+# MUST Monitor API Usage
+
+Owners of APIs used in production must monitor the API service to get
+information about how its clients are using it. This information, for instance, is
+useful to identify potential review partners for API changes.

--- a/api-guidelines/pagination.md
+++ b/api-guidelines/pagination.md
@@ -26,11 +26,12 @@ pagination.
 **Note:** To provide a consistent look and feel of pagination patterns,
 you must stick to the [common query parameter names](naming.md#must-stick-to-conventional-query-parameters).
 
-# SHOULD Prefer Cursor-Based Pagination, Avoid Offset-Based Pagination
+# SHOULD Assess whether cursor or offset based pagination is most suitable
 
 Cursor-based pagination is usually better and more efficient when
 compared to offset-based pagination. Especially when it comes to
-high-data volumes and / or storage in NoSQL databases.
+high-data volumes and / or storage in NoSQL databases. However, cursor based
+pagination can also be harder to use as an API consumer.
 
 Before choosing cursor-based pagination, consider the following
 trade-offs:

--- a/api-guidelines/pagination.md
+++ b/api-guidelines/pagination.md
@@ -1,0 +1,77 @@
+# MUST Support Pagination
+
+Access to lists of data items must support pagination to protect the
+service against overload as well as for best client side iteration and
+batch processing experience. This holds true for all lists that are
+(potentially) larger than just a few hundred entries.
+
+There are two well known page iteration techniques:
+
+  - [Offset/Limit-based
+    pagination](https://developer.infoconnect.com/paging-results):
+    numeric offset identifies the first page entry
+
+  - [Cursor/Limit-based](https://dev.twitter.com/overview/api/cursoring)
+    — aka key-based — pagination: a unique key element identifies the
+    first page entry (see also [Facebook’s
+    guide](https://developers.facebook.com/docs/graph-api/using-graph-api/v2.4#paging))
+
+The technical conception of pagination should also consider user
+experience related issues. As mentioned in this
+[article](https://www.smashingmagazine.com/2016/03/pagination-infinite-scrolling-load-more-buttons/),
+jumping to a specific page is far less used than navigation via
+`next`/`prev` page links. This favours cursor-based over offset-based
+pagination.
+
+**Note:** To provide a consistent look and feel of pagination patterns,
+you must stick to the [common query parameter names](naming.md#must-stick-to-conventional-query-parameters).
+
+# SHOULD Prefer Cursor-Based Pagination, Avoid Offset-Based Pagination
+
+Cursor-based pagination is usually better and more efficient when
+compared to offset-based pagination. Especially when it comes to
+high-data volumes and / or storage in NoSQL databases.
+
+Before choosing cursor-based pagination, consider the following
+trade-offs:
+
+  - Usability/framework support:
+    
+      - Offset / limit based pagination is more known than cursor-based
+        pagination, so it has more framework support and is easier to
+        use for API clients
+
+  - Use case: Jump to a certain page
+    
+      - If jumping to a particular page in a range (e.g., 51 of 100) is
+        really a required use case, cursor-based navigation is not
+        feasible
+
+  - Variability of data may lead to anomalies in result pages
+    
+      - Offset-based pagination may create duplicates or lead to missing
+        entries if rows are inserted or deleted between two subsequent
+        paging requests.
+    
+      - When using cursor-based pagination, paging cannot continue when
+        the cursor entry has been deleted while fetching two pages
+
+  - Performance considerations - efficient server-side processing using
+    offset-based pagination is hardly feasible for:
+    
+      - Higher data list volumes, especially if they do not reside in
+        the database’s main memory
+    
+      - Sharded or NoSQL databases
+
+  - Cursor-based navigation may not work if you need the total count of
+    results and / or backward iteration support
+
+Further reading:
+
+  - [Twitter](https://dev.twitter.com/rest/public/timelines)
+
+  - [Use the Index, Luke](http://use-the-index-luke.com/no-offset)
+
+  - [Paging in
+    PostgreSQL](https://www.citusdata.com/blog/1872-joe-nelson/409-five-ways-paginate-postgres-basic-exotic)

--- a/api-guidelines/references.md
+++ b/api-guidelines/references.md
@@ -1,0 +1,63 @@
+This section collects links to documents to which we refer, and base our
+guidelines on.
+
+# OpenAPI Specification
+
+  - [OpenAPI
+    Specification](https://github.com/OAI/OpenAPI-Specification/)
+
+# Publications, specifications and standards
+
+  - [RFC 3339: Date and Time on the Internet:
+    Timestamps](https://tools.ietf.org/html/rfc3339)
+
+  - [RFC 5988: Web Linking](https://tools.ietf.org/html/rfc5988)
+
+  - [RFC 7159: The JavaScript Object Notation (JSON) Data Interchange
+    Format](https://tools.ietf.org/html/rfc7159)
+
+  - [RFC 7230: Hypertext Transfer Protocol (HTTP/1.1): Message Syntax
+    and Routing](https://tools.ietf.org/html/rfc7230)
+
+  - [RFC 7231: Hypertext Transfer Protocol (HTTP/1.1): Semantics and
+    Content](https://tools.ietf.org/html/rfc7231)
+
+  - [RFC 7807: Problem Details for HTTP
+    APIs](https://tools.ietf.org/html/rfc7807)
+
+  - [ISO 8601: Date and time
+    format](https://en.wikipedia.org/wiki/ISO_8601)
+
+  - [ISO 3166-1 alpha-2: Two letter country
+    codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+
+  - [ISO 639-1: Two letter language
+    codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+
+  - [ISO 4217: Currency codes](https://en.wikipedia.org/wiki/ISO_4217)
+
+  - [BCP 47: Tags for Identifying
+    Languages](https://tools.ietf.org/html/bcp47)
+
+# Dissertations
+
+  - [Roy Thomas Fielding - Architectural Styles and the Design of
+    Network-Based Software
+    Architectures](http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm).
+    This is the text which defines what REST is.
+
+# Books
+
+  - [REST in Practice: Hypermedia and Systems
+    Architecture](http://www.amazon.de/REST-Practice-Hypermedia-Systems-Architecture/dp/0596805829)
+
+  - [Build APIs You Won’t
+    Hate](https://leanpub.com/build-apis-you-wont-hate)
+
+  - [InfoQ eBook - Web APIs: From Start to
+    Finish](http://www.infoq.com/minibooks/emag-web-api)
+
+# Blogs
+
+  - [Lessons-learned blog: Thoughts on RESTful API
+    Design](http://restful-api-design.readthedocs.org/en/latest/)

--- a/api-guidelines/resources.md
+++ b/api-guidelines/resources.md
@@ -1,0 +1,173 @@
+# MUST Avoid Actions — Think About Resources
+
+REST is all about your resources, so consider the domain entities that
+take part in web service interaction, and aim to model your API around
+these using the standard HTTP methods as operation indicators. For
+instance, if an application has to lock articles explicitly so that only
+one user may edit them, create an article lock with PUT or POST instead
+of using a lock action.
+
+Request:
+
+``` http
+PUT /article-locks/{article-id}
+```
+
+The added benefit is that you already have a service for browsing and
+filtering article locks.
+
+# SHOULD Model complete business processes
+
+An API should contain the complete business processes containing all
+resources representing the process. This enables clients to understand
+the business process, foster a consistent design of the business
+process, allow for synergies from description and implementation
+perspective, and eliminates implicit invisible dependencies between
+APIs.
+
+In addition, it prevents services from being designed as thin wrappers
+around databases, which normally tends to shift business logic to the
+clients.
+
+# SHOULD Define *useful* resources
+
+As a rule of thumb resources should be defined to cover 90% of all its
+client’s use cases. A *useful* resource should contain as much
+information as necessary, but as little as possible. A great way to
+support the last 10% is to allow clients to specify their needs for
+more/less information by supporting filtering and embedding.
+
+# MUST Keep URLs Verb-Free
+
+The API describes resources, so the only place where actions should
+appear is in the HTTP methods. In URLs, use only nouns. Instead of
+thinking of actions (verbs), it’s often helpful to think about putting a
+message in a letter box: e.g., instead of having the verb *cancel* in
+the url, think of sending a message to cancel an order to the
+*cancellations* letter box on the server side.
+
+# MUST Use Domain-Specific Resource Names
+
+API resources represent elements of the application’s domain model.
+Using domain-specific nomenclature for resource names helps developers
+to understand the functionality and basic semantics of your resources.
+It also reduces the need for further documentation outside the API
+definition. For example, "sales-order-items" is superior to
+"order-items" in that it clearly indicates which business object it
+represents. Along these lines, "items" is too general.
+
+# MUST Use URL-friendly Resource Identifiers: \[a-zA-Z0-9:.\_-\]\*
+
+To simplify encoding of resource IDs in URLs, their representation must
+only consist of ASCII strings of letters, numbers, underscore, minus,
+colon, and period.
+
+# MUST Identify resources and Sub-Resources via Path Segments
+
+Some API resources may contain or reference sub-resources. Embedded
+sub-resources, which are not top-level resources, are parts of a
+higher-level resource and cannot be used outside of its scope.
+Sub-resources should be referenced by their name and identifier in the
+path segments.
+
+Composite identifiers must not contain `/` as a separator. In order to
+improve the consumer experience, you should aim for intuitively
+understandable URLs, where each sub-path is a valid reference to a
+resource or a set of resources. For example, if
+`/customers/12ev123bv12v/addresses/DE_100100101` is a valid path of your
+API, then `/customers/12ev123bv12v/addresses`, `/customers/12ev123bv12v`
+and `/customers` must be valid as well in principle.
+
+Basic URL structure:
+
+``` http
+/{resources}/[resource-id]/{sub-resources}/[sub-resource-id]
+/{resources}/[partial-id-1][separator][partial-id-2]
+```
+
+Examples:
+
+``` http
+/carts/1681e6b88ec1/items
+/carts/1681e6b88ec1/items/1
+/customers/12ev123bv12v/addresses/DE_100100101
+/content/images/9cacb4d8
+```
+
+# SHOULD Consider Use of Nested URLs
+
+If a sub-resource is only accessible via its parent resource and may not
+exists without parent resource, consider using a nested URL structure,
+for instance:
+
+``` http
+/carts/1681e6b88ec1/cart-items/1
+```
+
+However, if the resource can be accessed directly via its unique id,
+then the API should expose it as a top-level resource. For example,
+customer has a collection for sales orders; however, sales orders have
+globally unique id and some services may choose to access the orders
+directly, for instance:
+
+``` http
+/customers/1681e6b88ec1
+/sales-orders/5273gh3k525a
+```
+
+# SHOULD Limit number of Resource types
+
+To keep maintenance and service evolution manageable, we should follow
+"functional segmentation" and "separation of concern" design principles
+and do not mix different business functionalities in same API
+definition. In practice this means that the number of resource types
+exposed via an API should be limited. In this context a resource type is
+defined as a set of highly related resources such as a collection, its
+members and any direct sub-resources.
+
+For example, the resources below would be counted as three resource
+types, one for customers, one for the addresses, and one for the
+customers' related addresses:
+
+``` http
+/customers
+/customers/{id}
+/customers/{id}/preferences
+/customers/{id}/addresses
+/customers/{id}/addresses/{addr}
+/addresses
+/addresses/{addr}
+```
+
+Note that:
+
+  - We consider `/customers/{id}/preferences` part of the `/customers`
+    resource type because it has a one-to-one relation to the customer
+    without an additional identifier.
+
+  - We consider `/customers` and `/customers/{id}/addresses` as separate
+    resource types because `/customers/{id}/addresses/{addr}` also
+    exists with an additional identifier for the address.
+
+  - We consider `/addresses` and `/customers/{id}/addresses` as separate
+    resource types because there’s no reliable way to be sure they are
+    the same.
+
+Given this definition, our experience is that well defined APIs involve
+no more than 4 to 8 resource types. There may be exceptions with more
+complex business domains that require more resources, but you should
+first check if you can split them into separate subdomains with distinct
+APIs.
+
+Nevertheless one API should hold all necessary resources to model
+complete business processes helping clients to understand these flows.
+
+# SHOULD Limit number of Sub-Resource Levels
+
+There are main resources (with root url paths) and sub-resources (or
+"nested" resources with non-root urls paths). Use sub-resources if their
+life cycle is (loosely) coupled to the main resource, i.e. the main
+resource works as collection resource of the subresource entities. You
+should use <= 3 sub-resource (nesting) levels — more levels increase API
+complexity and url path length. (Remember, some popular web browsers do
+not support URLs of more than 2000 characters)

--- a/api-guidelines/security.md
+++ b/api-guidelines/security.md
@@ -1,0 +1,20 @@
+# Security
+
+# MUST Only expose external APIs via SSL
+
+Any external API service must be encrypted using the current best practice for SSL connectivity. Plain HTTP connections should not be redirected to HTTPS, rather they should return an error code (normally a 403 Forbidden error)
+
+# MAY Expose internal APIs via SSL
+
+Depending on the network configuration it may or may not be appropriate to apply SSL encryption on APIs that are used internally.
+
+# SHOULD Use a standard authentication mechanism
+
+Access to an API should be controlled using a standard authentication mechanism such as OAuth/OpenID Connect.
+
+# MUST Not expose Stack Traces
+
+Stack traces contain implementation details that are not part of an API,
+and on which clients should never rely. Moreover, stack traces can leak
+sensitive information that partners and third parties are not allowed to
+receive and may disclose insights about vulnerabilities to attackers.

--- a/api-guidelines/security.md
+++ b/api-guidelines/security.md
@@ -1,12 +1,8 @@
 # Security
 
-# MUST Only expose external APIs via SSL
+# MUST Only expose APIs via SSL
 
-Any external API service must be encrypted using the current best practice for SSL connectivity. Plain HTTP connections should not be redirected to HTTPS, rather they should return an error code (normally a 403 Forbidden error)
-
-# MAY Expose internal APIs via SSL
-
-Depending on the network configuration it may or may not be appropriate to apply SSL encryption on APIs that are used internally.
+Any API service must be encrypted using the current best practice for SSL connectivity. Plain HTTP connections should not be redirected to HTTPS, rather they should return an error code (normally a 403 Forbidden error)
 
 # SHOULD Use a standard authentication mechanism
 


### PR DESCRIPTION
Please use this PR to review what's been added here wrt what we discussed in the workshop this week.

It includes:
 - pulling across the content (and reworking following our discussions) from bjpirt/api-guidelines
 - adding the 12 factor guidelines from LBHackney-IT/Hackney-Development-Standards
 - ensuring that all of the content from LBHackney-IT/Hackney-API-Standards is represented in this repo

These other two repos should be removed once their content has been consolidated into this one.
