### PR TITLE
Suggust use the json api `errors` field

### DIFF
--- a/api-guidelines/data-formats.md
+++ b/api-guidelines/data-formats.md
@@ -41,7 +41,7 @@ We use the status code to represent the success or failure of a request. We also
 ```JSON
 {
     "status" : "fail",
-    "data" : { "title" : "A title is required" }
+    "errors" : [ "A title is required" ]
 }
 ```
 


### PR DESCRIPTION
Some reasoning for the change:
- the JSON API standards suggest using a root level `errors` array
- The tenancy and property API use an errors field
- Using a map with the field name as the key leaves the question on what to do when there is a multi-field error or a general error