### PR TITLE
Documentation

### DIFF
--- a/docs/aws_good_practices.md
+++ b/docs/aws_good_practices.md
@@ -1,5 +1,0 @@
----
-id: aws_good_practices
-title: AWS API Gateway good practices
----
-TBC 

--- a/docs/aws_lambda.md
+++ b/docs/aws_lambda.md
@@ -1,5 +1,0 @@
----
-id: aws_lambda
-title: AWS Lambda and when to use
----
-TBC 

--- a/docs/containerisation.md
+++ b/docs/containerisation.md
@@ -1,5 +1,0 @@
----
-id: containerisation
-title: Containerisation for end-to-end users
----
-TBC

--- a/docs/security_monitoring.md
+++ b/docs/security_monitoring.md
@@ -1,6 +1,0 @@
----
-id: security_monitoring
-title: Security Monitoring
----
-
-TBC 

--- a/docs/storing_secrets.md
+++ b/docs/storing_secrets.md
@@ -1,6 +1,0 @@
----
-id: storing_secrets
-title: Storing Secrets
----
-
-TBC 

--- a/docs/uptime_monitoring.md
+++ b/docs/uptime_monitoring.md
@@ -2,3 +2,32 @@
 id: uptime_monitoring
 title: Uptime Monitoring
 ---
+
+
+
+## Centralised Uptime Monitoring
+
+Hackney now has multiple Platform APIs deployed to the AWS cloud. Each API is a self-contained application exposing a specific set of data.
+As we are creating and deploying multiple APIs in AWS It’s necessary to be able to monitor the health and performance of these applications. AWS provides a centralised monitoring and logging solution of the applications.
+
+We can monitor the uptime performance of individual endpoints and APIs using AWS Canaries.
+
+
+## AWS Canaries
+
+AWS canaries are accessible via the CloudWatch console. Amazon defines a canary as configurable scripts that run on a schedule to monitor your endpoints and APIs.
+A canary can be configured to make scheduled requests to a health check endpoint.
+
+CloudWatch is the AWS console or dashboard for managing operational data such as logs, metrics and events.
+Canaries are used for all Platform API production environments.
+
+Monitoring the health and performance of staging environments has no long-term benefit in relation to production environments. Production applications are public facing and any downtime should be immediately signalled and logged by the deployment environment. When downtime is signalled we can investigate the cause via the CloudWatch logs. Each Platform API canary calls a production environment API endpoint at a regular interval.
+
+
+## Canary Configuration
+
+Canaries can be configured to run once or on a user defined schedule. A scheduled canary can run for 24 hours a day as often as once per minute. A canary also has configurable alarm parameters. These are parameters which will set off an alarm in CloudWatch if the defined conditions are met.
+Alarm parameters can be very specific and granular.
+
+A canary will require any authorization headers and values needed to access the API in the configuration.
+Accessing the dashboard for a Canary in CloudWatch lets you view the status of the Canary over a period of time.

--- a/docs/uptime_monitoring.md
+++ b/docs/uptime_monitoring.md
@@ -31,3 +31,24 @@ Alarm parameters can be very specific and granular.
 
 A canary will require any authorization headers and values needed to access the API in the configuration.
 Accessing the dashboard for a Canary in CloudWatch lets you view the status of the Canary over a period of time.
+
+## Setting up Canaries
+
+** Creating a canary which will ping an endpoint and check the response **
+
+- In the aws console go to, cloud watch then click on ** canaries ** .
+
+          https://signin.aws.amazon.com/signin?redirect_uri=https%3A%2F%2Feu-west-2.console.aws.amazon.com%2Fcloudwatch%2Fhome%3Fregion%3Deu-west-2%26state%3DhashArgs%2523synthetics%253Acanary%252Flist%26isauthcode%3Dtrue&client_id=arn%3Aaws%3Aiam%3A%3A015428540659%3Auser%2Fcloudwatch&forceMobileApp=0&code_challenge=afPX8AredTuJ4RR-8tmbbYoDccc2YpaukmzbN5Up2z4&code_challenge_method=SHA-256
+
+- Click on ** "Create Canary" ** , choose ** "Use a blueprint" ** and  ** "Heartbeat monitoring"** .
+
+- Give a name which makes it easily recognisable as whats it is (try and get the name of the API and the endpoint it's testing)
+
+
+** <u> Checking a 200 response </u> **
+
+** <u> Altering the code to check a 404 is returned </u> **
+
+For more information, check out the aws documentation below:
+
+              https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Create.html

--- a/sidebars.js
+++ b/sidebars.js
@@ -21,7 +21,7 @@ module.exports = {
       'branching_strategy',
 
       {
-        'API Practices and Tools': ['linting','static_code_analysis', 'storing_secrets']
+        'API Practices and Tools': ['linting','static_code_analysis',]
       },
       {
         'DevOps Practices': ['deployment_pipeline', 'infrastructure']
@@ -30,14 +30,14 @@ module.exports = {
       {
         type: 'category',
         label: 'How to build an API',
-        items: ['preferred_tech_stack', 'api_boilerplate',{'Testing': ['tdd', 'unit_test', 'integration_tests', 'containerisation']}]
+        items: ['preferred_tech_stack', 'api_boilerplate',{'Testing': ['tdd', 'unit_test', 'integration_tests']}]
       },
 
     {
-    'Deploying your API': ['aws_lambda', 'aws_ecs', 'aws_good_practices']
+    'Deploying your API': [ 'aws_ecs',]
     },
     {
-    'Monitoring': ['centralised_logging', 'uptime_monitoring', 'security_monitoring', 'alerting']
+    'Monitoring': ['centralised_logging', 'uptime_monitoring','alerting']
     },
     {
     'Securing your API': ['api_keys', {'Lambda authoriser': ['generating_tokens']}]


### PR DESCRIPTION
 The following empty Sections in the API Playbook have seen removed : 

- Storing Secrets 
- Deployment Pipeline
- AWS Lambda and when to use
- AWS API Good Practices
- Security Monitoring 
- Containerisation for End to End Users 

-Uptime Monitoring has been updated with "Centralised Uptime Monitoring " and " Setting up canaries"


