### PR TITLE
Add syntax highlighting to C# code blocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,6 +10,9 @@ module.exports = {
   organizationName: "lbhackney-it",
   projectName: "API-Playbook",
   themeConfig: {
+    prism: {
+      additionalLanguages: ["csharp"],
+    },
     navbar: {
       title: "API Playbook",
       logo: {


### PR DESCRIPTION
[Other languages](https://prismjs.com/#supported-languages) can be added to the array on line 14 to enable syntax highlighting for them as well. I only need C# for now.