### PR TITLE
Update Algolia Search Credentials

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,7 +28,7 @@ module.exports = {
       ],
     },
     algolia: {
-      apiKey: '4a83a5c4eb60fa0e4dae66ff84553e02',
+      apiKey: '4dc9b48c851c09d44e9cf356d5425867',
       indexName: 'hackney',
       placeholder: 'Search playbook'
     },


### PR DESCRIPTION
DocSearch, which we use for searching on the playbook, recently migrated their apps to new accounts. (See [here](https://docsearch.algolia.com/docs/migrating-from-legacy/)).

This PR updates the credentials as emailed to me.