### PR TITLE
Fix SSL Certificates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,7 @@ workflows:
             - build-deploy-production:
                   requires:
                       - permit-deploy-production
+                      - terraform-init-and-apply-to-production
                   filters:
                       branches:
                           only: /release\/.*/

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -21,5 +21,5 @@ module "playbook_distribution" {
   cost_code           = "B0811"
   project_name        = "hackney-playbooks"
   use_cloudfront_cert = false
-  hackney_cert_arn    = "arn:aws:acm:eu-west-2:${data.aws_caller_identity.current.account_id}:certificate/20e17f4b-2a75-462c-ba1c-2b9429f19b93"
+  hackney_cert_arn    = "arn:aws:acm:eu-west-2:${data.aws_caller_identity.current.account_id}:certificate/de3298d7-7f2a-45b7-8cd3-4769839cdbcc"
 }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -21,5 +21,5 @@ module "playbook_distribution" {
   cost_code           = "B0811"
   project_name        = "hackney-playbooks"
   use_cloudfront_cert = false
-  hackney_cert_arn    = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/dbb3198e-b779-41b6-80b3-4ffd5dd19bf4"
+  hackney_cert_arn    = "arn:aws:acm:eu-west-2:${data.aws_caller_identity.current.account_id}:certificate/20e17f4b-2a75-462c-ba1c-2b9429f19b93"
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -21,6 +21,6 @@ module "playbook_distribution" {
   cost_code           = "B0811"
   project_name        = "hackney-playbooks"
   use_cloudfront_cert = false
-  hackney_cert_arn    = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d"
+  hackney_cert_arn    = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/4877809f-989f-4e31-9a1a-4c054f00b51e"
   web_acl_id = "arn:aws:wafv2:us-east-1:${data.aws_caller_identity.current.account_id}:global/webacl/FE_Web_ACL/679f5ebc-fb36-48ae-88c3-be4b55598720"
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -18,6 +18,6 @@ module "playbook_distribution" {
   environment_name    = "staging"
   cost_code           = "B0811"
   project_name        = "hackney-playbooks"
-  use_cloudfront_cert = false
-  hackney_cert_arn    = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a"
+  use_cloudfront_cert = true
+  hackney_cert_arn    = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/" // Update once certificate is made
 }


### PR DESCRIPTION
Update SSL certificates ARNs to use dedicated certificates instead of `*hackney.gov.uk` wildcard ones.

_Note: The staging certificate must be verified first, which may take a couple of days. It is using the default CloudFront cert for now._