### PR TITLE
Remove tech radar origin from playbook

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -17,7 +17,6 @@ data "aws_caller_identity" "current" {}
 locals {
   environment_name = "development"
   origins = {
-    "tech-radar-frontend-${local.environment_name}"   = "tech-radar"
     "api-playbook-frontend-${local.environment_name}" = "API-Playbook"
   }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -17,7 +17,6 @@ data "aws_caller_identity" "current" {}
 locals {
   environment_name = "production"
   origins = {
-    "tech-radar-frontend-${local.environment_name}"   = "tech-radar"
     "api-playbook-frontend-${local.environment_name}" = "API-Playbook"
   }
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -17,7 +17,6 @@ data "aws_caller_identity" "current" {}
 locals {
   environment_name = "staging"
   origins = {
-    "tech-radar-frontend-${local.environment_name}"   = "tech-radar"
     "api-playbook-frontend-${local.environment_name}" = "API-Playbook"
   }
 }


### PR DESCRIPTION
We're about to remove the Tech Radar because it's out of date and no longer maintained. This change removes the origin, which will remove the S3 bucket and and WAF configuration next time the terraform is run.

The variables here are used in the [playbook-distro branch of the aws-hackney-common-terraform](https://github.com/LBHackney-IT/aws-hackney-common-terraform/tree/playbook-distro). There it iterates over the contents of `origins`, so removing this element won't break any references there.

## Dependencies

- The tech radar S3 buckets need to be empty so Terraform can successfully destroy the resource.
- The tech radar frontend Cloudfront distribution needs to be destroyed so the access identity isn't in use any more (again for Terraform).