### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHRShetty @humulla


### PR DESCRIPTION
In preparation for the global mandatory PR rules, this CODEOWNERS file is out of date. We probably want a single team to own the repo, but until we've figured that out we can remove all code owners. This means the existing workflow of anyone in Hackney approving PRs can continue.