### PR TITLE
Destroy old infra and mark as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,3 @@
-# API Playbook
+# API Playbook (🛑 Deprecated)
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
-You can view the API Playbook here: [https://playbook.hackney.gov.uk/API-Playbook](https://playbook.hackney.gov.uk/API-Playbook)
-
-## Installation
-
-```console
-yarn install
-```
-
-## Local Development
-
-```console
-yarn start
-```
-
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the su7866erver.
-
-## Build
-
-```console
-yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Contributing
-This repository follows **Trunk-Based Development**.
-
-- To contribute, make Pull Requests to the `main` branch. You will be able to preview your changes once you make a PR on the development environment (todo: add link)
-- Once your PR is approved and merged, your changes will be deployed to staging (todo: add link)
-- To create a production release, create a `release` branch from the `main` branch (following the pattern `release/*`). Your changes will be deployed to [https://playbook.hackney.gov.uk/API-Playbook](https://playbook.hackney.gov.uk/API-Playbook).
+The content from this repository has been migrated to https://github.com/LBHackney-IT/lbhackney-it.github.io.

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -21,14 +21,3 @@ locals {
     "api-playbook-frontend-${local.environment_name}" = "API-Playbook"
   }
 }
-
-module "playbook_distribution" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/playbook-hosting/without-waf?ref=playbook-distro"
-  cname_aliases       = ["playbook-development.hackney.gov.uk"]
-  environment_name    = local.environment_name
-  cost_code           = "B0811"
-  project_name        = "hackney-playbooks"
-  use_cloudfront_cert = false
-  origins             = local.origins
-  hackney_cert_arn    = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/de3298d7-7f2a-45b7-8cd3-4769839cdbcc"
-}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -21,15 +21,3 @@ locals {
     "api-playbook-frontend-${local.environment_name}" = "API-Playbook"
   }
 }
-
-module "playbook_distribution" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/playbook-hosting/with-waf?ref=playbook-distro"
-  cname_aliases       = ["playbook.hackney.gov.uk"]
-  environment_name    = local.environment_name
-  cost_code           = "B0811"
-  project_name        = "hackney-playbooks"
-  use_cloudfront_cert = false
-  origins             = local.origins
-  hackney_cert_arn    = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/4877809f-989f-4e31-9a1a-4c054f00b51e"
-  web_acl_id = "arn:aws:wafv2:us-east-1:${data.aws_caller_identity.current.account_id}:global/webacl/FE_Web_ACL/679f5ebc-fb36-48ae-88c3-be4b55598720"
-}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -21,14 +21,3 @@ locals {
     "api-playbook-frontend-${local.environment_name}" = "API-Playbook"
   }
 }
-
-module "playbook_distribution" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/playbook-hosting/without-waf?ref=playbook-distro"
-  cname_aliases       = [] // "playbook-staging.hackney.gov.uk"
-  environment_name    = local.environment_name
-  cost_code           = "B0811"
-  project_name        = "hackney-playbooks"
-  use_cloudfront_cert = true
-  origins             = local.origins
-  hackney_cert_arn    = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/" // Update once certificate is made
-}


### PR DESCRIPTION
The content from this repository has been migrated to https://github.com/LBHackney-IT/lbhackney-it.github.io.

This change should trigger the destruction of the old resources in AWS.